### PR TITLE
Analysis modifications needed for manipulation benchmarks

### DIFF
--- a/benchmarks/other/benchmark_utilities/benchmark_utilities/analysis/__init__.py
+++ b/benchmarks/other/benchmark_utilities/benchmark_utilities/analysis/__init__.py
@@ -596,6 +596,7 @@ class BenchmarkAnalyzer:
 
             elif not target and image_pipeline_msgs[index].event.name in self.power_chain:  # optimization
      
+                # NOTE: Modify this logic if more power traces are added in the future (currently there's only one)
                 image_pipeline_msg_sets.append(image_pipeline_msgs[index])
 
         return image_pipeline_msg_sets

--- a/benchmarks/other/benchmark_utilities/benchmark_utilities/analysis/__init__.py
+++ b/benchmarks/other/benchmark_utilities/benchmark_utilities/analysis/__init__.py
@@ -595,78 +595,8 @@ class BenchmarkAnalyzer:
                         new_set = []  # restart
 
             elif not target and image_pipeline_msgs[index].event.name in self.power_chain:  # optimization
-
-                if debug:
-                    print("---")
-                    print("new: " + image_pipeline_msgs[index].event.name)
-                    print("expected: " + str(self.power_chain[chain_index]))
-                    print("chain_index: " + str(chain_index))
-
-                # first one            
-                if (
-                    chain_index == 0
-                    and image_pipeline_msgs[index].event.name == self.power_chain[chain_index]
-                ):
-                    new_set.append(image_pipeline_msgs[index])
-                    vpid_chain = image_pipeline_msgs[index].event.common_context_field.get(
-                        "vpid"
-                    )
-                    chain_index += 1
-                    if debug:
-                        print(color("Found: " + str(image_pipeline_msgs[index].event.name) + " - " + str([x.event.name for x in new_set]), fg="blue"))
-                # last one
-                elif (
-                    image_pipeline_msgs[index].event.name == self.power_chain[chain_index]
-                    and self.power_chain[chain_index] == self.power_chain[-1]
-                    and new_set[-1].event.name == self.power_chain[-2]
-                    and image_pipeline_msgs[index].event.common_context_field.get("vpid")
-                    == vpid_chain
-                ):
-                    new_set.append(image_pipeline_msgs[index])
-                    image_pipeline_msg_sets.append(new_set)
-                    if debug:
-                        print(color("Found: " + str(image_pipeline_msgs[index].event.name) + " - " + str([x.event.name for x in new_set]), fg="blue"))
-                    chain_index = 0  # restart
-                    new_set = []  # restart
-                # match
-                elif (
-                    image_pipeline_msgs[index].event.name == self.power_chain[chain_index]
-                    and image_pipeline_msgs[index].event.common_context_field.get("vpid")
-                    == vpid_chain
-                ):
-                    new_set.append(image_pipeline_msgs[index])
-                    chain_index += 1
-                    if debug:
-                        print(color("Found: " + str(image_pipeline_msgs[index].event.name) + " - " + str([x.event.name for x in new_set]), fg="green"))
-                # altered order
-                elif (
-                    image_pipeline_msgs[index].event.name in self.power_chain
-                    and image_pipeline_msgs[index].event.common_context_field.get("vpid")
-                    == vpid_chain
-                ):
-                    # pop ros2:callback_start in new_set, if followed by "ros2:callback_end"
-                    # NOTE: consider case of disconnected series of:
-                    #       "ros2:callback_start"
-                    #       "ros2:callback_end"
-                    if (image_pipeline_msgs[index].event.name == "ros2:callback_end"
-                        and self.power_chain[chain_index - 1] == "ros2:callback_start"):
-                        new_set.pop()
-                        chain_index -= 1
-                    # # it's been observed that "robotperf_benchmarks:robotperf_image_input_cb_init" triggers
-                    # # before "ros2_image_pipeline:image_proc_rectify_cb_fini" which leads to trouble
-                    # # Skip this as well as the next event
-                    # elif (image_pipeline_msgs[index].event.name == "robotperf_benchmarks:robotperf_image_input_cb_init"
-                    #     and self.power_chain[chain_index - 3] == "ros2_image_pipeline:image_proc_rectify_cb_fini"):
-                    #     print(color("Skipping: " + str(image_pipeline_msgs[index].event.name), fg="yellow"))
-                    # elif (image_pipeline_msgs[index].event.name == "robotperf_benchmarks:robotperf_image_input_cb_fini"
-                    #     and self.power_chain[chain_index - 3] == "ros2_image_pipeline:image_proc_rectify_cb_fini"):
-                    #     print(color("Skipping: " + str(image_pipeline_msgs[index].event.name), fg="yellow"))
-                    else:
-                        new_set.append(image_pipeline_msgs[index])
-                        if debug:
-                            print(color("Altered order: " + str([x.event.name for x in new_set]) + ", restarting", fg="red"))
-                        chain_index = 0  # restart
-                        new_set = []  # restart
+     
+                image_pipeline_msg_sets.append(image_pipeline_msgs[index])
 
         return image_pipeline_msg_sets
 
@@ -1422,10 +1352,9 @@ class BenchmarkAnalyzer:
                 # power_chain_joules.append(joules)
                 # power_chain_seconds.append(seconds)
             
-            image_pipeline_msg_sets_watts.append(power_chain_watts)
             # image_pipeline_msg_sets_joules.append(power_chain_joules)
             # image_pipeline_msg_sets_seconds.append(power_chain_seconds) 
-            total_watts = image_pipeline_msg_sets_watts[-1]
+            total_watts = power_chain_watts[-1]
             # total_joules = image_pipeline_msg_sets_joules[-1]
             # total_seconds = image_pipeline_msg_sets_seconds[-1]      
 

--- a/benchmarks/other/benchmark_utilities/benchmark_utilities/analysis/__init__.py
+++ b/benchmarks/other/benchmark_utilities/benchmark_utilities/analysis/__init__.py
@@ -2566,7 +2566,7 @@ class BenchmarkAnalyzer:
         else:
             power_consumption = None
         
-        if self.trace_sets_filter_type == "":
+        if not hasattr(self, 'trace_sets_filter_type'):
             self.set_trace_sets_filter_type()
 
         self.get_target_chain_traces(tracepath)        
@@ -2605,7 +2605,7 @@ class BenchmarkAnalyzer:
         else:
             power_consumption = None
 
-        if self.trace_sets_filter_type == "":
+        if not hasattr(self, 'trace_sets_filter_type'):
             self.set_trace_sets_filter_type()
         
         self.get_target_chain_traces(tracepath)        
@@ -2678,7 +2678,7 @@ class BenchmarkAnalyzer:
             return result["value"]
         else:
             # default to grey-box benchmarking
-            if self.trace_sets_filter_type == "":
+            if not hasattr(self, 'trace_sets_filter_type'):
                 self.set_trace_sets_filter_type()
 
             self.get_power_chain_traces(tracepath)        
@@ -2754,13 +2754,13 @@ class BenchmarkAnalyzer:
         """
 
         if self.hardware_device_type == "fpga":
-            print("FPGA traces can only be analyzed by name because vtf traces won't have a unique identifier")
+            print("FPGA trace sets can only be filtered by name because vtf traces won't have a unique identifier")
             # No need to set the analysis_type property since it is not evaluated down the road with FPGA hardware
             return
 
         if filter_type == "name" or filter_type == "ID":
-            print("Setting {} method")
+            print("Setting {} method for filtering trace sets".format(filter_type))
             self.trace_sets_filter_type = filter_type
         else:
-            print("Type {} for analyzing traces does not exist, setting message ID analysis type".format(filter_type))
+            print("Type {} for filtering trace sets does not exist, setting message ID analysis type".format(filter_type))
             self.trace_sets_filter_type = "ID"


### PR DESCRIPTION
This PR addresses changes needed for pushing the first `manipulation` benchmark:
- Configure the `BenchmarkAnalyzer` so trace sets are filtered either by name or unique ID (so far we did this by commenting/uncommenting):
  ```python3
  ba.set_trace_sets_filter_type("ID")  
  ```
  or
  ```python3
  ba.set_trace_sets_filter_type("name")  
  ```
- Get the power trace sets by name instead of ID. Even though there's no real difference given that only one power trace is generated, I added this trivial modification for consistency.

In order not to affect the CI with this PR:
- If not specified, the filtering method used is by unique identifier.
- Thus, no modifications are required unless we explicitly need to filter by name, which will be only the case for manipulation as of now.
- I've analyzed `a1` and `c1` traces and checked that there are no errors with PR changes (`b` only uses black-box, no analysis there) and results are correctly generated.