### PR TITLE
Set first and last targets dynamically in benchmark analysis

### DIFF
--- a/benchmarks/other/benchmark_utilities/benchmark_utilities/analysis/__init__.py
+++ b/benchmarks/other/benchmark_utilities/benchmark_utilities/analysis/__init__.py
@@ -1777,29 +1777,8 @@ class BenchmarkAnalyzer:
         max_ = self.max_sets(image_pipeline_msg_sets_ms)
         #median_ = self.median_sets(image_pipeline_msg_sets_ms)
 
-        # first_target = "ros2:callback_end"
-        first_target = "robotperf_benchmarks:robotperf_image_input_cb_init"
-        last_target = "robotperf_benchmarks:robotperf_image_output_cb_init"
-        
-        # # NOTE: we can particularizations for first_target and last_target
-        # #       as needed, e.g.
-        if "a4" in self.benchmark_name:
-            last_target = "robotperf_benchmarks:robotperf_pointcloud_output_cb_init"
-
-        if "c1" in self.benchmark_name:
-            first_target = "robotcore_control:robotcore_control_joint_trajectory_controller_cb_init"
-            last_target = "robotcore_control:robotcore_control_joint_trajectory_controller_cb_fini"
-
-        if "c2" in self.benchmark_name:
-            first_target = "robotcore_control:robotcore_control_diff_drive_controller_cb_init"
-            last_target = "robotcore_control:robotcore_control_diff_drive_controller_cb_fini"
-
-        if ("c3" in self.benchmark_name or "c4" in self.benchmark_name or "c5" in self.benchmark_name):
-            first_target = "robotcore_control:robotcore_control_forward_command_controller_cb_init"
-            last_target = "robotcore_control:robotcore_control_forward_command_controller_cb_fini"
-
-        #
-        # NOTE 2: find a way to parametrize this into the class
+        first_target = self.target_chain[0]
+        last_target = self.target_chain[-1]
 
         indices = [i for i in range(
                     self.target_chain_dissambiguous.index(first_target),


### PR DESCRIPTION
This PR sets the `first_target` and `last_target` using the configuration specified in the analysis launch file.
For instance, for `a1` the `first_target` is specified [here](https://github.com/robotperf/benchmarks/blob/main/benchmarks/perception/a1_perception_2nodes/launch/analyze_a1_perception_2nodes.launch.py#L75-L85) and the `last_target` is specified [here](https://github.com/robotperf/benchmarks/blob/main/benchmarks/perception/a1_perception_2nodes/launch/analyze_a1_perception_2nodes.launch.py#L196-L206).
This eliminates the need for setting those variables depending on the benchmark being analyzed.

Manually tested for:
- `a1`
- `c1`
- `d1`